### PR TITLE
[Feature] [Refactor] Integrated slash commands into DM and refactored inversion command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { Client, Events, SlashCommandBuilder, GatewayIntentBits } from 'discord.js';
+import { Client, Events, SlashCommandBuilder, GatewayIntentBits, Partials } from 'discord.js';
 
 const client = new Client({
     intents: [
@@ -9,7 +9,11 @@ const client = new Client({
         GatewayIntentBits.GuildMessages, 
         GatewayIntentBits.GuildMembers, 
         GatewayIntentBits.DirectMessages,
-        GatewayIntentBits.MessageContent
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.DirectMessages
+    ],
+    partials: [
+        Partials.Channel
     ]
 });
 
@@ -26,6 +30,8 @@ client.once(Events.ClientReady, readyClient => {
     const invert = new SlashCommandBuilder()
         .setName('inversion')
         .setDescription('Inverts the message you send')
+        .setIntegrationTypes([0, 1])
+        .setContexts([0, 1, 2])
         .addStringOption(option =>
             option.setName('message')
                 .setDescription('The message to be inverted')
@@ -47,18 +53,8 @@ client.on(Events.InteractionCreate, interaction => {
     if (interaction.commandName === 'inversion') {
         const message = interaction.options.get('message').value;
         
-        let stack = [];
-        let invertedMessage = "";
-        
-        // Add characters in message to stack
-        for (const char of message) {
-            stack.push(char);
-        }
-
-        // Reverse order of characters from message
-        for (let char = 0; stack.length; char++) {
-            invertedMessage += stack.pop();
-        }
+        // Reverse string
+        let invertedMessage = message.split("").reverse().join("");
 
         interaction.reply(invertedMessage);
     }


### PR DESCRIPTION
## Summary
Currently, adding a bot to a server only gives access to its slash commands within that server. 

The slash commands registered with this bot are now accessible across all chats, from servers to group DM's to personal DM's. Additionally, code for the inversion slash command was refactored to a single line.

For the DM integration, the DirectMessages intent and Channel partial were added to allow the bot to access DM's, in addition to adding two additional methods to the structure of the inversion slash command to allow for the installation of the app and its interactions to be used everywhere. For the inversion refactor, the use of a stack was removed to opt for a simplistic one-liner fix, using in-built methods to deconstruct the characters of the message into an array, reverse the order of the array, and then concatenate them back together as a string. 

## References
[Discord.js](https://discord.js.org/docs/packages/discord.js/14.19.3/SlashCommandBuilder:Class#options)
[Discord.js Application Resource](https://discord.com/developers/docs/resources/application#application-object-application-integration-types)
[Discord.js Interactions](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types)
