### PR TITLE
[Feature] Automated titling and archival of threads

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { Client, Events, SlashCommandBuilder, GatewayIntentBits, Partials } from 'discord.js';
+import { Client, Events, SlashCommandBuilder, GatewayIntentBits, Partials, InteractionCallback} from 'discord.js';
 
 const client = new Client({
     intents: [
@@ -9,13 +9,20 @@ const client = new Client({
         GatewayIntentBits.GuildMessages, 
         GatewayIntentBits.GuildMembers, 
         GatewayIntentBits.DirectMessages,
-        GatewayIntentBits.MessageContent,
-        GatewayIntentBits.DirectMessages
+        GatewayIntentBits.MessageContent, 
+        GatewayIntentBits.GuildMessageReactions
     ],
     partials: [
-        Partials.Channel
+        Partials.Channel,
+        Partials.Message
     ]
 });
+
+// Global  variables
+const LINK_REGEX = /https:\/\/discord.com\/channels\/(@me|\d{19})\/(\d{18}|\d{19})\/(\d{19})/;
+const THREAD_TITLE_REGEX = /(?<=\*\*)(.*?)(?=\*\*)/;
+let THREAD_CONFIRMATION_ID = '';
+let ARCHIVED_THREAD = '';
 
 // Confirm bot is logged in
 client.once(Events.ClientReady, readyClient => {
@@ -37,8 +44,21 @@ client.once(Events.ClientReady, readyClient => {
                 .setDescription('The message to be inverted')
                 .setRequired(true));
     
+    // Create talking point slash command
+    const talkingPoint = new SlashCommandBuilder()
+        .setName('tp')
+        .setDescription('Sends talking point to talking point channel')
+        .setIntegrationTypes([0, 1])
+        .setContexts([0, 1, 2])
+        .addStringOption(option =>
+            option.setName('link')
+                .setDescription('The message link to be sent')
+                .setRequired(true)); 
+    
     client.application.commands.create(ping);
     client.application.commands.create(invert);
+    client.application.commands.create(talkingPoint);
+
 });
 
 // Listen for slash commands
@@ -49,16 +69,71 @@ client.on(Events.InteractionCreate, interaction => {
         interaction.reply('Pong!');
     }
 
-    // inversion slash command
+    // Inversion slash command
     if (interaction.commandName === 'inversion') {
         const message = interaction.options.get('message').value;
         
         // Reverse string
-        let invertedMessage = message.split("").reverse().join("");
+        let invertedMessage = message.split('').reverse().join('');
 
         interaction.reply(invertedMessage);
     }
 })
+
+// Listen for threads being created
+client.on(Events.ThreadCreate, async (thread) => {
+    console.log(`Thread created: ${thread.name} in ${thread.parent.name}`);
+     
+    try {
+        // Grab message thread was created
+        const threadMessage = await thread.fetchStarterMessage();
+        console.log(`Thread created from message: ${threadMessage.content}`);
+
+        // Automate thread title by grabbing from starter message 
+        const threadTitleMatch = threadMessage.content.match(THREAD_TITLE_REGEX);
+        if (threadTitleMatch && threadTitleMatch[0]) {
+            thread.setName(threadTitleMatch[0]);
+        }
+    } 
+    catch (error) {
+        console.error('Error fetching starter message:', error);
+    }
+});
+
+// Listen for threads being archived
+client.on(Events.ThreadUpdate, (oldThread, newThread) => {
+    if (oldThread.archived === false && newThread.archived === true) {
+        console.log(`Thread ${newThread.name} has been archived`);
+
+        // Bot sends confirmation message for archiving thread
+        const parentChannel = client.channels.cache.get(newThread.parentId);
+        parentChannel.send(`Are you sure you want to archive ${newThread.name}? Confirm you've processed everything`);
+        setTimeout(function() {
+            console.log(parentChannel.lastMessageId);
+            THREAD_CONFIRMATION_ID = parentChannel.lastMessageId;
+        }, 1000)
+        ARCHIVED_THREAD = newThread;
+    }
+});
+
+// Listen for reactions to messages
+client.on(Events.MessageReactionAdd, async (reaction) => {
+    // Check if message reacted to is from bot
+    if (reaction.message.author.id === client.user.id && reaction.message.id === THREAD_CONFIRMATION_ID) {
+        // Get the emoji
+        const emoji = reaction.emoji.name;
+        const parentChannel = reaction.message.channel;
+
+        // Check the reaction emoji for thread archival confirmation
+        if (emoji === '👍') {
+            parentChannel.send(`You've confirmed the archival of the thread`);
+        }
+        else if (emoji === '👎') {
+            parentChannel.send(`You've elected to reopen the thread`);
+            ARCHIVED_THREAD.setArchived(false);
+        }
+    }
+});
 
 // Log into Discord
 client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
This feature addresses two problems with threads: 1) you have to manually add titles for new threads for messages that already include titles and 2) the loss of knowledge potential from closing unprocessed threads. 

Messages that are used to initiate new threads include titles with them. Instead of having to input a title for newly created threads, the same title as the message is automatically used for the thread. Manually closing or the closing of threads due to inactivity will automatically auto-prompt a message confirming whether or not we want to reopen a thread to continue discussion or if they're finished and ready for processing. 

When a new thread is created, it's title is grabbed using regex and used as the title for the newly created thread. When a thread is updated (manually or due to inactivity), its status as *now* being archived is confirmed. If it has been archived, the bot sends a message for confirmation on its archival. You can react to the message with a thumbs up or thumbs down emoji and the bot will either keep the thread archived or reopen the thread. 

## References
[Discord.js](https://discordjs.guide/popular-topics/threads.html#thread-related-gateway-events)
