### PR TITLE
[Feature] Implemented Discord -> Marvin task pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.19.3",
-        "dotenv": "^16.5.0"
+        "dotenv": "^16.5.0",
+        "nodemailer": "^7.0.3"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -251,6 +252,14 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "description": "",
   "dependencies": {
     "discord.js": "^14.19.3",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "nodemailer": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
Two integral features were added:
1. Threads that are confirmed archived (as of last commit) automatically create a task in Marvin to process messages in thread
2. Slash command to create tasks in-platform that are sent to Marvin

## Why do we need these features?
As of last commit (automated titling and archiving of threads), we want to avoid systemic knowledge rot from forgotten Discord thread discussions. It's not reliable to rely on our memories and motivation to create tasks to process these discussions, which can and will result in a loss of valuable information, which is why automating it's so important. In the same manner, there's less resistance when there's an option to create a task while still in Discord, rather than having to switch apps to do the same work, which also neglects the possibility of a task requiring the tracking of two people. 

### (1) Processing threads task sent to Marvin
**Solution:**
- Reacting with a thumbs up emoji to the bot message confirms thread being archived
- This triggers a new processing task to be created in Marvin via nodemailer

### (2) Slash command for adding new task
**Solution:**
- Slash command `/addtask` is registered
- Using command, you can add a new task to Marvin via nodemailer
- You have a boolean "mirror" option to choose whether or not you want the task created for both you and the other user

## Testing
**Manual Testing:**
![image](https://github.com/user-attachments/assets/8b40c226-14cb-4d9d-8592-6598077493e4)
![image](https://github.com/user-attachments/assets/f7172018-b4a5-4cec-84bb-d54967155403)

## References
[Node.js](https://discordjs.guide/creating-your-bot/slash-commands.html#before-you-continue)
[Nodemailer](https://nodemailer.com/)

